### PR TITLE
PER-232 updated auth pattern for handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
 Git [bridge-adapter] (2020-10-13)
 * [repo_copy_template_v1]
     * initial commit.
+
+Git [bridge-adapter] (2021-09-27å)
+* [repo_copy_template_v1]
+    * PER-232 made password optional and username encrypted to support github's PAT for authentication.

--- a/handlers/repo_copy_template_v1/changelog.md
+++ b/handlers/repo_copy_template_v1/changelog.md
@@ -1,2 +1,5 @@
 Repo Copy Template V1 (2020-01-22)
  * Initial version.  See README for details.
+
+Repo Copy Template V1 (2021-09-27)
+ * PER-232 made password optional and username encrypted to support github's PAT for authentication.

--- a/handlers/repo_copy_template_v1/process/info.xml
+++ b/handlers/repo_copy_template_v1/process/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <taskInfo version="1.0">
-  <info name="git_username" required="true" description="The username for the git hosting service"></info>
-  <info name="git_password" required="true" description="The password for the git hosting service" type="encrypted"></info>
+  <info name="git_username" required="true" description="The username for the git hosting service" type="encrypted"></info>
+  <info name="git_password" description="The password for the git hosting service" type="encrypted"></info>
   <info name="enable_debug_logging" description="True or False">false</info>
 </taskInfo>

--- a/handlers/repo_copy_template_v1/readme.md
+++ b/handlers/repo_copy_template_v1/readme.md
@@ -14,3 +14,4 @@
 
 ### Notes
   * It is assumed that the user has rights to both the source and destination urls.
+  * To support GitHubs Personal Access Token (PAT) authentication the username has is encrypted and the password is optional.  To authenticate to Github for repo push/pull place the PAT into the username field and leave the password field blank.

--- a/handlers/repo_copy_template_v1/test/get_input.rb
+++ b/handlers/repo_copy_template_v1/test/get_input.rb
@@ -1,11 +1,12 @@
 {
   'info' => {
-    'git_username' => "FooBar",
-    'git_password' => ""
+    'git_username' => "",
+    'git_password' => "",
+    'enable_debug_logging' => "true"
   },
   'parameters' => {
     'error_handling' => 'Error Message',
-    'source_repository' => 'https://github.com/ChadRehmKineticData/template.git',
-    'destination_repository' => 'https://github.com/ChadRehmKineticData/template-2.git',
+    'source_repository' => 'https://github.com/FooBar/template.git',
+    'destination_repository' => 'https://github.com/FooBar/template-2.git',
   }
 }


### PR DESCRIPTION
The git repo clone handler needed to be updated to support github's PAT authentication pattern.  It just required encrypting the username so that the PAT can be entered in the field and making the password optional so that a black can be passed for the password.